### PR TITLE
Add CRT color modes for textures

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 #include <SDL2/SDL.h>
@@ -43,7 +44,8 @@
 
 static void usage(void)
 {
-    fprintf(stderr, "usage: %s [-fm] [-l level] [-V volume]\n", PROG_NAME);
+    fprintf(stderr,
+        "usage: %s [-fm] [-c mode] [-l level] [-V volume]\n", PROG_NAME);
 }
 
 static void error(char *fmt, ...)
@@ -131,9 +133,22 @@ int main(int argc, char **argv)
     int start_level = 1;
     int volume = 100;
     Uint32 wflags = 0;
+    enum color_mode color = COLOR_ORIGINAL;
 
-    while ((ch = getopt(argc, argv, "fl:mV:")) != -1) {
+    while ((ch = getopt(argc, argv, "c:fl:mV:")) != -1) {
         switch (ch) {
+        case 'c':
+            if (strcmp(optarg, "original") == 0) {
+                color = COLOR_ORIGINAL;
+            } else if (strcmp(optarg, "green") == 0) {
+                color = COLOR_GREEN;
+            } else if (strcmp(optarg, "white") == 0) {
+                color = COLOR_WHITE;
+            } else {
+                error("invalid color mode: %s", optarg);
+                return EXIT_FAILURE;
+            }
+            break;
         case 'f':
             wflags |= SDL_WINDOW_FULLSCREEN;
             break;
@@ -203,6 +218,7 @@ int main(int argc, char **argv)
     }
 
     texture_init(renderer);
+    texture_set_color_mode(color);
     sound_init();
     sound_volume(volume);
 
@@ -234,6 +250,10 @@ int main(int argc, char **argv)
                     case SDLK_q:
                         start = true;
                         goto eog;
+                    case SDLK_c:
+                        texture_set_color_mode(
+                            (texture_color_mode() + 1) % COLOR_MODE_SIZE);
+                        break;
                     case SDLK_ESCAPE:
                     case SDLK_p:
                         pause = !pause;

--- a/texture.c
+++ b/texture.c
@@ -24,40 +24,130 @@
 #include "texture.h"
 
 static SDL_Texture *textures[TEXTURE_SIZE] = {NULL};
+// Original, untinted RGBA pixels for each persistent texture. Kept so the
+// color mode can be re-applied at runtime without reloading files.
+static SDL_Surface *sources[TEXTURE_SIZE] = {NULL};
+static enum color_mode current_mode = COLOR_ORIGINAL;
 
 /*
- * Load texture image from file.
- * Calls die() on error.
+ * Rewrite dst from src, applying the given color mode. Both surfaces must be
+ * RGBA32 and have identical dimensions. dst and src may alias.
+ *
+ * Monochrome modes collapse each pixel to its luminance, then paint that
+ * brightness in the phosphor's color -- matching how a monochrome CRT renders
+ * a signal regardless of the source's original hue.
+ */
+static void apply_color_mode(SDL_Surface *dst, SDL_Surface *src,
+    enum color_mode mode)
+{
+    // Phosphor tint per mode, scaled by each pixel's luminance.
+    static const Uint8 tint[COLOR_MODE_SIZE][3] = {
+        [COLOR_ORIGINAL] = {0, 0, 0}, // unused
+        [COLOR_GREEN] = {0x33, 0xFF, 0x33},
+        [COLOR_WHITE] = {0xFF, 0xFF, 0xFF},
+    };
+
+    int n = src->w * src->h;
+    Uint32 *sp = src->pixels;
+    Uint32 *dp = dst->pixels;
+
+    for (int i = 0; i < n; i++) {
+        Uint8 r, g, b, a;
+        SDL_GetRGBA(sp[i], src->format, &r, &g, &b, &a);
+
+        if (mode != COLOR_ORIGINAL) {
+            // Rec.601 luma with integer weights summing to 256.
+            Uint32 lum = (77 * r + 150 * g + 29 * b) >> 8;
+            r = tint[mode][0] * lum / 255;
+            g = tint[mode][1] * lum / 255;
+            b = tint[mode][2] * lum / 255;
+        }
+
+        dp[i] = SDL_MapRGBA(dst->format, r, g, b, a);
+    }
+}
+
+// Load an image file as an RGBA32 surface. Calls die() on error.
+static SDL_Surface *load_surface(char *file)
+{
+    char *path = path_join(TEXTURES_DIR, file);
+    SDL_Surface *loaded = IMG_Load(path);
+    free(path);
+    if (loaded == NULL) {
+        die("failed to load texture: %s", IMG_GetError());
+    }
+
+    SDL_Surface *rgba = SDL_ConvertSurfaceFormat(loaded, SDL_PIXELFORMAT_RGBA32, 0);
+    SDL_FreeSurface(loaded);
+    if (rgba == NULL) {
+        die("failed to convert texture: %s", SDL_GetError());
+    }
+
+    return rgba;
+}
+
+/*
+ * Load texture image from file, applying the current color mode.
+ * Calls die() on error. Used for transient images not affected by runtime
+ * color mode toggling.
  */
 SDL_Texture *texture_load(SDL_Renderer *renderer, char *file)
 {
-    char *path = path_join(TEXTURES_DIR, file);
-    SDL_Texture *texture = IMG_LoadTexture(renderer, path);
-    free(path);
+    SDL_Surface *rgba = load_surface(file);
+    apply_color_mode(rgba, rgba, current_mode);
 
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, rgba);
+    SDL_FreeSurface(rgba);
     if (texture == NULL) {
-        die("failed to load texture: %s", IMG_GetError());
+        die("failed to create texture: %s", SDL_GetError());
     }
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+
+    return texture;
+}
+
+// Load a persistent texture, keeping its original pixels so the color mode can
+// be re-applied later via texture_set_color_mode().
+static SDL_Texture *load_persistent(SDL_Renderer *renderer, char *file, int idx)
+{
+    SDL_Surface *src = load_surface(file);
+    sources[idx] = src;
+
+    SDL_Texture *texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA32,
+        SDL_TEXTUREACCESS_STATIC, src->w, src->h);
+    if (texture == NULL) {
+        die("failed to create texture: %s", SDL_GetError());
+    }
+    SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+
+    SDL_Surface *tmp = SDL_CreateRGBSurfaceWithFormat(0, src->w, src->h, 32,
+        SDL_PIXELFORMAT_RGBA32);
+    if (tmp == NULL) {
+        die("failed to create surface: %s", SDL_GetError());
+    }
+    apply_color_mode(tmp, src, current_mode);
+    SDL_UpdateTexture(texture, NULL, tmp->pixels, tmp->pitch);
+    SDL_FreeSurface(tmp);
 
     return texture;
 }
 
 void texture_init(SDL_Renderer *renderer)
 {
-    textures[TEXTURE_BRICK] = texture_load(renderer, "brick.png");
+    textures[TEXTURE_BRICK] = load_persistent(renderer, "brick.png", TEXTURE_BRICK);
     textures[TEXTURE_EMPTY] = NULL;
-    textures[TEXTURE_GOLD] = texture_load(renderer, "gold.png");
-    textures[TEXTURE_GUARD] = texture_load(renderer, "guard.png");
-    // texture_map[TILE_HLADDER] = texture_load(renderer, ".png");
-    textures[TEXTURE_HOLE] = texture_load(renderer, "hole.png");
-    textures[TEXTURE_LADDER] = texture_load(renderer, "ladder.png");
-    textures[TEXTURE_PAUSED] = texture_load(renderer, "paused.png");
-    textures[TEXTURE_ROPE] = texture_load(renderer, "rope.png");
-    textures[TEXTURE_RUNNER] = texture_load(renderer, "runner.png");
-    textures[TEXTURE_SOLID] = texture_load(renderer, "solid.png");
-    // texture_map[TILE_TRAP] = texture_load(renderer, ".png");
-    textures[TEXTURE_GROUND] = texture_load(renderer, "ground.png");
-    textures[TEXTURE_TEXT] = texture_load(renderer, "text.png");
+    textures[TEXTURE_GOLD] = load_persistent(renderer, "gold.png", TEXTURE_GOLD);
+    textures[TEXTURE_GUARD] = load_persistent(renderer, "guard.png", TEXTURE_GUARD);
+    // texture_map[TILE_HLADDER] = load_persistent(renderer, ".png", ...);
+    textures[TEXTURE_HOLE] = load_persistent(renderer, "hole.png", TEXTURE_HOLE);
+    textures[TEXTURE_LADDER] = load_persistent(renderer, "ladder.png", TEXTURE_LADDER);
+    textures[TEXTURE_PAUSED] = load_persistent(renderer, "paused.png", TEXTURE_PAUSED);
+    textures[TEXTURE_ROPE] = load_persistent(renderer, "rope.png", TEXTURE_ROPE);
+    textures[TEXTURE_RUNNER] = load_persistent(renderer, "runner.png", TEXTURE_RUNNER);
+    textures[TEXTURE_SOLID] = load_persistent(renderer, "solid.png", TEXTURE_SOLID);
+    // texture_map[TILE_TRAP] = load_persistent(renderer, ".png", ...);
+    textures[TEXTURE_GROUND] = load_persistent(renderer, "ground.png", TEXTURE_GROUND);
+    textures[TEXTURE_TEXT] = load_persistent(renderer, "text.png", TEXTURE_TEXT);
 }
 
 void texture_destroy(void)
@@ -65,10 +155,40 @@ void texture_destroy(void)
     for (int i = 0; i < TEXTURE_SIZE; i++) {
         SDL_DestroyTexture(textures[i]);
         textures[i] = NULL;
+        if (sources[i] != NULL) {
+            SDL_FreeSurface(sources[i]);
+            sources[i] = NULL;
+        }
     }
 }
 
 SDL_Texture *texture_get(enum texture t)
 {
     return textures[t];
+}
+
+void texture_set_color_mode(enum color_mode mode)
+{
+    current_mode = mode;
+
+    for (int i = 0; i < TEXTURE_SIZE; i++) {
+        SDL_Surface *src = sources[i];
+        if (src == NULL || textures[i] == NULL) {
+            continue;
+        }
+
+        SDL_Surface *tmp = SDL_CreateRGBSurfaceWithFormat(0, src->w, src->h, 32,
+            SDL_PIXELFORMAT_RGBA32);
+        if (tmp == NULL) {
+            die("failed to create surface: %s", SDL_GetError());
+        }
+        apply_color_mode(tmp, src, mode);
+        SDL_UpdateTexture(textures[i], NULL, tmp->pixels, tmp->pitch);
+        SDL_FreeSurface(tmp);
+    }
+}
+
+enum color_mode texture_color_mode(void)
+{
+    return current_mode;
 }

--- a/texture.h
+++ b/texture.h
@@ -20,6 +20,17 @@
 
 #include <SDL.h>
 
+enum color_mode {
+    // Original full-color sprites.
+    COLOR_ORIGINAL,
+    // Monochrome green phosphor CRT.
+    COLOR_GREEN,
+    // Monochrome white phosphor CRT.
+    COLOR_WHITE,
+    // Keep it last.
+    COLOR_MODE_SIZE,
+};
+
 enum texture {
     TEXTURE_BRICK,
     TEXTURE_EMPTY,
@@ -43,5 +54,10 @@ SDL_Texture *texture_load(SDL_Renderer *renderer, char *file);
 void texture_init(SDL_Renderer *renderer);
 void texture_destroy(void);
 SDL_Texture *texture_get(enum texture t);
+
+// Set the active color mode and re-render all loaded textures in place.
+// Existing texture handles remain valid, so cached sprite pointers keep working.
+void texture_set_color_mode(enum color_mode mode);
+enum color_mode texture_color_mode(void);
 
 #endif /* TEXTURE_H_ */


### PR DESCRIPTION
## Summary

Adds a display palette toggle for pure retro indulgence: the original color mode, plus **green-on-black** and **white-on-black** monochrome modes.

## Why

Because some of us did not first meet *Lode Runner* in glorious color.

We met it glowing from a questionable Apple-compatible machine, on a humming CRT, in phosphor green or stark black-and-white, where every ladder, brick, guard, and panic-digged hole looked like it came from a half-remembered childhood dream.

This PR brings that feeling back.

## Changes

* While keeping the original color palette, added both a cli argument `-c` and a color scheme toggle (press `c`)


<img width="1123" height="769" alt="green" src="https://github.com/user-attachments/assets/65e0844c-025e-40d8-bda7-c526a501ad7c" />
<img width="1123" height="771" alt="white" src="https://github.com/user-attachments/assets/91e56c94-299e-4d83-a903-0a6fc0c30574" />
<img width="1124" height="772" alt="original" src="https://github.com/user-attachments/assets/b431e8ef-0e14-424d-89be-436b2715f4c2" />
